### PR TITLE
[*] Allows to get raw message with order_id, etc for FilledOrder object

### DIFF
--- a/bitshares/price.py
+++ b/bitshares/price.py
@@ -425,7 +425,7 @@ class FilledOrder(Price):
     def __init__(self, order, bitshares_instance=None, **kwargs):
 
         self.bitshares = bitshares_instance or shared_bitshares_instance()
-
+        self["_bitshares_raw_object"] = order
         if isinstance(order, dict) and "price" in order:
             super(FilledOrder, self).__init__(
                 order.get("price"),
@@ -450,6 +450,9 @@ class FilledOrder(Price):
 
         else:
             raise ValueError("Couldn't parse 'Price'.")
+
+    def get_raw_object(self):
+        return self["_bitshares_raw_object"]
 
     def __repr__(self):
         t = ""


### PR DESCRIPTION
Make info from market.accounttrades more verbose.
Perhaps the same should be added to most of methods.