### PR TITLE
Return newly created SignedTransaction when `sign` is invoked.

### DIFF
--- a/bitshares/transactionbuilder.py
+++ b/bitshares/transactionbuilder.py
@@ -345,6 +345,7 @@ class TransactionBuilder(dict):
 
         signedtx.sign(self.wifs, chain=self.blockchain.rpc.chain_params)
         self["signatures"].extend(signedtx.json().get("signatures"))
+        return signedtx
 
     def verify_authority(self):
         """ Verify the authority of the signed transaction


### PR DESCRIPTION
This is useful for tearing down/rebuilding and passing transactions around.