### PR TITLE
Allow empty list as AccountCreateExtension(s) -- for real this time.

### DIFF
--- a/bitsharesbase/objects.py
+++ b/bitsharesbase/objects.py
@@ -319,7 +319,7 @@ class AccountCreateExtensions(Extension):
                 if isArgsThisClass(self, args):
                         self.data = args[0].data
                 else:
-                    if len(args) == 1 and len(kwargs) == 0 and not(isinstance(args[0], list)):
+                    if len(args) == 1 and len(kwargs) == 0:
                         kwargs = args[0]
 #                    assert "1.3.0" in kwargs["markets"], "CORE asset must be in 'markets' to pay fees"
                     super().__init__(OrderedDict([
@@ -333,7 +333,7 @@ class AccountCreateExtensions(Extension):
         if isArgsThisClass(self, args):
             self.data = args[0].data
         else:
-            if len(args) == 1 and len(kwargs) == 0:
+            if len(args) == 1 and len(kwargs) == 0 and not(isinstance(args[0], list)):
                 kwargs = args[0]
 
         self.json = dict()


### PR DESCRIPTION
Previous PR #90 erroneously adjusted Buyback_options instead of AccountCreateExtensions. :( Terribly sorry about that. This is the correct fix.