### PR TITLE
Set init0 as default account in message tests.

### DIFF
--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -18,6 +18,7 @@ class Testcases(unittest.TestCase):
             wif=[wif]
         )
         set_shared_bitshares_instance(self.bts)
+        self.bts.set_default_account("init0")
 
     def test_sign_message(self):
         def new_refresh(self):


### PR DESCRIPTION
I'm not entirely sure this is the right thing to do, but
a) other tests seem to do it
b) "init0" is NOT the default config option