### PR TITLE
Fix broken hostname

### DIFF
--- a/bitshares/storage.py
+++ b/bitshares/storage.py
@@ -235,7 +235,7 @@ class Configuration(DataDir):
 
     #: Default configuration
     config_defaults = {
-        "node": "wss://node.bitshares.eu",
+        "node": "wss://eu.nodes.bitshares.ws",
         "rpcpassword": "",
         "rpcuser": "",
         "order-expiration": 7 * 24 * 60 * 60,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -18,7 +18,7 @@ class Testcases(unittest.TestCase):
         )
 
         b2 = BitShares(
-            "wss://node.bitshares.eu",
+            "wss://eu.nodes.bitshares.ws",
             nobroadcast=True,
         )
 
@@ -33,7 +33,7 @@ class Testcases(unittest.TestCase):
         test = Asset("1.3.0")
 
         b2 = BitShares(
-            "wss://node.bitshares.eu",
+            "wss://eu.nodes.bitshares.ws",
             nobroadcast=True,
         )
         set_shared_bitshares_instance(b2)

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -11,7 +11,7 @@ class Testcases(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(Testcases, self).__init__(*args, **kwargs)
         bitshares = BitShares(
-            "wss://node.bitshares.eu",
+            "wss://eu.nodes.bitshares.ws",
             nobroadcast=True,
         )
         set_shared_bitshares_instance(bitshares)


### PR DESCRIPTION
The .eu hostnames are no longer working and seem to have been replaced with .ws hostnames.