### PR TITLE
Fix init of FilledOrder from history op

### DIFF
--- a/bitshares/price.py
+++ b/bitshares/price.py
@@ -564,7 +564,7 @@ class FilledOrder(Price):
         elif isinstance(order, dict):
             # filled orders from account history
             if "op" in order:
-                order = order["op"]
+                order = order["op"][1]
             base_asset = kwargs.get("base_asset", order["receives"]["asset_id"])
             super(FilledOrder, self).__init__(
                 order,


### PR DESCRIPTION
Fixes the following:

    o = FilledOrder(entry, bitshares_instance=bitshares, base_asset=Asset('USD'))
  File "/home/vvk/.local/share/virtualenvs/market-scripts-BfRrkhQ4/src/bitshares/bitshares/price.py", line 568, in __init__
    base_asset = kwargs.get("base_asset", order["receives"]["asset_id"])
TypeError: list indices must be integers or slices, not str