### PR TITLE
Fix potential infinite generator in `Market.trades`.

### DIFF
--- a/bitshares/market.py
+++ b/bitshares/market.py
@@ -285,6 +285,8 @@ class Market(BlockchainInstance, dict):
                     formatTime(start),
                     continuous_limit)
 
+            if len(orders) == 0:
+                return
             for order in orders:
                 cnt += 1
                 yield FilledOrder(


### PR DESCRIPTION
Since 5924ac129721f432f3e44d8390dba0c895014ab0 was added, `Market.trades` is a generator and not a function. In it, there is a single exit condition -- `cnt >= limit`. However, this condition might never be reached for situations, where the number of returned results is less than required limit.

The simplest test to verify this is to open an empty market  -- `trades` will never return. Similar thing could happen if you ask for, eg, 50 trades, but the start - stop interval only has 30.