### PR TITLE
#128 Proposal fix

### DIFF
--- a/bitshares/market.py
+++ b/bitshares/market.py
@@ -358,6 +358,7 @@ class Market(BlockchainInstance, dict):
         account = Account(account, full=True, blockchain_instance=self.blockchain)
 
         r = []
+        account.refresh()
         orders = account["limit_orders"]
         for o in orders:
             if ((


### PR DESCRIPTION
Now at least method `market,accountopenorders()` won't raise KeyError "limit_orders"