### PR TITLE
Memo padding edge cases

### DIFF
--- a/bitsharesbase/memo.py
+++ b/bitsharesbase/memo.py
@@ -63,8 +63,8 @@ def _pad(s, BS):
 
 
 def _unpad(s, BS):
-    count = int(struct.unpack('B', bytes(s[-1], 'ascii'))[0])
-    if bytes(s[-count::], 'ascii') == count * struct.pack('B', count):
+    count = s[-1]
+    if s[-count::] == count * struct.pack('B', count):
         return s[:-count]
     return s
 
@@ -116,6 +116,7 @@ def decode_memo(priv, pub, nonce, message):
     " TODO, verify checksum "
     message = cleartext[4:]
     try:
-        return _unpad(message.decode('utf8'), 16)
+        message = _unpad(message, 16)
     except Exception as e:
         raise ValueError(message)
+    return message.decode('utf8')

--- a/bitsharesbase/memo.py
+++ b/bitsharesbase/memo.py
@@ -110,10 +110,15 @@ def decode_memo(priv, pub, nonce, message):
     " Encryption "
     raw = bytes(message, 'ascii')
     cleartext = aes.decrypt(unhexlify(raw))
-    " TODO, verify checksum "
+    " Checksum "
+    checksum = cleartext[0:4]
     message = cleartext[4:]
     try:
         message = _unpad(message, 16)
     except Exception as e:
         raise ValueError(message)
+    " Verify checksum "
+    check = hashlib.sha256(message).digest()[0:4]
+    if check != checksum:
+        raise ValueError("checksum verification failure")
     return message.decode('utf8')

--- a/bitsharesbase/memo.py
+++ b/bitsharesbase/memo.py
@@ -87,10 +87,7 @@ def encode_memo(priv, pub, nonce, message):
     checksum = hashlib.sha256(raw).digest()
     raw = (checksum[0:4] + raw)
     " Padding "
-    BS = 16
-    " FIXME: this adds 16 bytes even if not required "
-    if len(raw) % BS:
-        raw = _pad(raw, BS)
+    raw = _pad(raw, 16)
     " Encryption "
     return hexlify(aes.encrypt(raw)).decode('ascii')
 

--- a/tests/test_memo.py
+++ b/tests/test_memo.py
@@ -87,8 +87,8 @@ class Testcases(unittest.TestCase):
     def test_padding(self):
         for l in range(0, 255):
             s = bytes(l * chr(l), 'utf-8')
-            padded = _pad(s, 16).decode('utf-8')
-            self.assertEqual(s.decode('utf-8'), _unpad(padded, 16))
+            padded = _pad(s, 16)
+            self.assertEqual(s, _unpad(padded, 16))
 
     def test_decrypt(self):
         for memo in test_cases:

--- a/tests/test_memo.py
+++ b/tests/test_memo.py
@@ -41,7 +41,19 @@ test_cases = [
      'nonce': '16332877645293003478',
      'plain': 'äöüß€@$²³',
      'to': 'GPH6HAMuJRkjGJkj6cZWBbTU13gkUhBep383prqRdExXsZsYTrWT5',
-     'wif': '5Jpkeq1jiNE8Pe24GxFWTsyWbcP59Qq4cD7qg3Wgd6JFJqJkoG8'}
+     'wif': '5Jpkeq1jiNE8Pe24GxFWTsyWbcP59Qq4cD7qg3Wgd6JFJqJkoG8'},
+    {'from': 'GPH6APYcWtrWXBhcrjPEhPz41bc98NxjnvufVVnRH1M8sjwtvFacz',
+     'message': '40b7ed2efd5e23b97e3f3aec6319fda722194e08b4cee45b84566e2741916797',
+     'nonce': '10864609094208714729',
+     'plain': '1234567890\x02\x02', # final bytes LOOK LIKE padding
+     'to': 'GPH7Ge953jTDzHKxFAzy19uhJtXxw8CbBM938hkSKWE3yXfRjLV57',
+     'wif': '5KR8jzysz2kbYy3TkL3x6NRxfNXwQUWyeVAF5ZagxdqKMawGgXG'},
+    {'from': 'GPH6APYcWtrWXBhcrjPEhPz41bc98NxjnvufVVnRH1M8sjwtvFacz',
+     'message': 'f43800298f9974c7b334bb1bf6224f236309520e99697f3980775231bfb4ef21',
+     'nonce': '8555724032490455626',
+     'plain': 'abcdefghijÛ', # padding limit and last character is unicode
+     'to': 'GPH7Ge953jTDzHKxFAzy19uhJtXxw8CbBM938hkSKWE3yXfRjLV57',
+     'wif': '5KR8jzysz2kbYy3TkL3x6NRxfNXwQUWyeVAF5ZagxdqKMawGgXG'},
 ]
 
 test_shared_secrets = [
@@ -57,6 +69,18 @@ test_shared_secrets = [
     ["5Jg7muALcVxncN32LyGMDK8zut2b1Sw3VJA1xjZE5ght7DRM9ac", "GPH5Vj6uR2iKmrB2DcFyqNzperycD3a32BBYkefzKYCHoGnXemwWS", "60928672da8e9a7dc0f783f2bf8aaf1b206b9bbd85f0a61b638e0b99f5f8ea56"],
 ]
 
+# This is a result of an olden/buggy padding implementation,
+# where "abcdefghijÛ" + 4 bytes of checksum == 16 bytes,
+# and no padding was applied. Since those are out there, we must
+# still try to handle this gracefully.
+not_enough_padding = [
+    {'from': 'GPH6APYcWtrWXBhcrjPEhPz41bc98NxjnvufVVnRH1M8sjwtvFacz',
+     'message': '0b93e05a3b017d00ee16dfea0c1a9d64',
+     'nonce': '7675159740645758991',
+     'plain': 'abcdefghijÛ',
+     'to': 'GPH7Ge953jTDzHKxFAzy19uhJtXxw8CbBM938hkSKWE3yXfRjLV57',
+     'wif': '5KR8jzysz2kbYy3TkL3x6NRxfNXwQUWyeVAF5ZagxdqKMawGgXG'},
+]
 
 class Testcases(unittest.TestCase):
 
@@ -103,3 +127,11 @@ class Testcases(unittest.TestCase):
                 get_shared_secret(sender_private_key, receiver_public_key),
                 get_shared_secret(receiver_private_key, sender_public_key)
             )
+
+    def test_decrypt_bugged_padding(self):
+        for memo in not_enough_padding:
+            dec = decode_memo(PrivateKey(memo["wif"]),
+                              PublicKey(memo["to"], prefix="GPH"),
+                              memo["nonce"],
+                              memo["message"])
+            self.assertEqual(memo["plain"], dec)


### PR DESCRIPTION
There are currently several inter-related bugs in the memo padding/unpadding mechanism.

1. The `_unpad` method tries to guess if the final byte of the message is a padding marker or an actual data byte.
```
    if bytes(s[-count::], 'ascii') == count * struct.pack('B', count):
```
this guesswork can fail, if, for example, the message ends with `\x02\x02` (yes, that should be possible, as it's a valid unicode string).

2. When doing this guesswork and fetching the final byte, the method is extremely prone to errors
```
    count = int(struct.unpack('B', bytes(s[-1], 'ascii'))[0])
```
This can fail if `s` was unicode- (and not ascii-) encoded. If we adjust it to
```
    count = int(struct.unpack('B', bytes(s[-1], 'utf8'))[0])
```
then, `bytes(s[-1], 'utf8')` might result in a multi-byte sequence and will break the call to `unpack('B')`, which expects a single byte.

To deal with both those cases, I've converted `_unpad` to use raw bytes, which removes any ambiguity with the final byte and re-encoding.

However, this still leaves another important bug: the guesswork should never happen at all! The messages prepared by `encode_memo` are *not properly padded*.

```python
    BS = 16
    " FIXME: this adds 16 bytes even if not required "
    if len(raw) % BS:
        raw = _pad(raw, BS)
```

Here, the comment claims "this adds 16 bytes even if not required ", however the **exact opposite** is happening! The code above "would not add padding to 16 byte-sized message, even as it IS required".

Consider the string `abcdefghijÛ`. There are 10 ascii characters, 1 unicode 2-byte character and 4 byte checksum (not shown here). Thus, 10+2+4 = 16. So, we're hitting an edge case and the above code WILL NOT add any padding. Now, the message ends with `Û` and the decoder has to *guess* if it's a final marker or not, as described above.

I've taken a look at `bitshares-core`, in it, there's no ambiguity or guesswork involved: the padding algorithm would just add another 16 bytes (full of padding markers) to such string.

To reiterate: "abcdefghijÛ" encoded with python-bitshares = 16 bytes, "abcdefghijÛ" encoded with bitshares-core = 32 bytes.

After applying the patches in this PR:
1. python-bitshares will start generating properly padded messages
2. it will **keep** the ability to decode improperly padded messages (via guesswork)