### PR TITLE
Fix buy/sell of near-precision amounts

### DIFF
--- a/bitshares/market.py
+++ b/bitshares/market.py
@@ -475,12 +475,12 @@ class Market(dict):
                 "seller": account["id"],
                 "amount_to_sell": {
                     "amount": int(
-                        float(amount) * float(price) * 10 ** self["base"]["precision"]
+                        round(float(amount) * float(price) * 10 ** self["base"]["precision"])
                     ),
                     "asset_id": self["base"]["id"],
                 },
                 "min_to_receive": {
-                    "amount": int(float(amount) * 10 ** self["quote"]["precision"]),
+                    "amount": int(round(float(amount) * 10 ** self["quote"]["precision"])),
                     "asset_id": self["quote"]["id"],
                 },
                 "expiration": formatTimeFromNow(expiration),
@@ -559,12 +559,12 @@ class Market(dict):
                 "fee": {"amount": 0, "asset_id": "1.3.0"},
                 "seller": account["id"],
                 "amount_to_sell": {
-                    "amount": int(float(amount) * 10 ** self["quote"]["precision"]),
+                    "amount": int(round(float(amount) * 10 ** self["quote"]["precision"])),
                     "asset_id": self["quote"]["id"],
                 },
                 "min_to_receive": {
                     "amount": int(
-                        float(amount) * float(price) * 10 ** self["base"]["precision"]
+                        round(float(amount) * float(price) * 10 ** self["base"]["precision"])
                     ),
                     "asset_id": self["base"]["id"],
                 },


### PR DESCRIPTION
Due to using floating point arithmetics amounts precision may be lost in
market buy/sell operations.

Testcase:

```
from bitshares import BitShares
from bitshares.amount import Amount

bitshares = BitShares()
amount = Amount('2.01 ESCROW.RUBLE', blockchain_instance=bitshares)

print(amount)
print(float(amount))
print(float(amount) * 10 ** amount['asset']['precision'])
print(int(float(amount) * 10 ** amount['asset']['precision']))
```

Output:

```
2.01 ESCROW.RUBLE
2.01
200.99999999999997
200
```