### PR TITLE
fix #175 for trade order is immediately canceled after being issued

### DIFF
--- a/bitshares/market.py
+++ b/bitshares/market.py
@@ -534,7 +534,9 @@ class Market(dict):
                 That way you can multiply prices with `1.05` to get a +5%.
         """
         if not expiration:
-            expiration = self.blockchain.config["order-expiration"]
+            expiration = (
+                self.blockchain.config["order-expiration"] or 60 * 60 * 24 * 365
+            )
         if not account:
             if "default_account" in self.blockchain.config:
                 account = self.blockchain.config["default_account"]


### PR DESCRIPTION
Sell order was immediately canceled after being issued. Now default expiration time is set to 1 year (similar to buy orders).

Issue [#175](https://github.com/bitshares/python-bitshares/issues/175)

