### PR TITLE
Update default API node to api.bts.mobi

### DIFF
--- a/bitshares/storage.py
+++ b/bitshares/storage.py
@@ -10,7 +10,7 @@ from graphenestorage import (
 )
 
 
-url = "wss://node.bitshares.eu"
+url = "wss://api.bts.mobi"
 SqliteConfigurationStore.setdefault("node", url)
 SqliteConfigurationStore.setdefault("order-expiration", 356 * 24 * 60 * 60)
 


### PR DESCRIPTION
The default node `wss://node.bitshares.eu` has been down for a relatively long time. We need to fix it or update it.