### PR TITLE
Remove link to hackthedex.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,5 +60,5 @@ A copy of the license is available in the repository's
 
 ### Bounties
 
-As part of [HackTheDex](https://hackthedex.io), security issues found in this
+Security issues found in this
 library are potentially eligible for a bounty.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,3 @@ Discussions around development and use of this library can be found in a
 
 A copy of the license is available in the repository's
 [LICENSE](LICENSE.txt) file.
-
-### Bounties
-
-Security issues found in this
-library are potentially eligible for a bounty.


### PR DESCRIPTION
The site was long down and the domain name is lost