### PR TITLE
Issue in notify websocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+venv/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/bitsharesapi/websocket.py
+++ b/bitsharesapi/websocket.py
@@ -237,6 +237,8 @@ class BitSharesWebsocket(Events):
         If we receive a ``notice``, we hand over post-processing and signalling of
         events to ``process_notice``.
         """
+        if isinstance(reply, websocket.WebSocketApp):
+            reply = args[0]
         log.debug("Received message: %s" % str(reply))
         data = {}
         try:


### PR DESCRIPTION
After following the following example, found [in the official docs][1], I noticed the callback method `def message(self, reply, *args, **kwargs)` in `class BitSharesWebsocket(Events)` would consistently raise and thus never print data to standard out.

**Example**

```python
from pprint import pprint
from bitshares.notify import Notify
from bitshares.market import Market

notify = Notify(
    markets=["TEST:GOLD"],
    accounts=["xeroc"],
    on_market=print,
    on_account=print,
    on_block=print,
    on_tx=print
)
notify.listen()
```

I looked for a test case of the the `Notify` class, but didn't find one. After writing a makeshift integration test, which sadly is not sufficient to commit to the repo, I found the issue and corrected it in this PR. I have seen this kind of issue previously. It looked to me like the underlying `websocket.WebSocketApp` class is intended to be used as a base class. But, I can't be 100% about that assumption.

Regardless, the code I am submitting in this PR does resolve the issue and was written in a way such that it should not impact other code.

**P.S.** 

Instead of rebasing, as you suggested [here][2], I just created this new PR.

[1]: http://docs.pybitshares.com/en/latest/bitshares.notify.html
[2]: https://github.com/bitshares/python-bitshares/pull/309