### PR TITLE
add seed for random in test fixture

### DIFF
--- a/tests/testnet/aio/conftest.py
+++ b/tests/testnet/aio/conftest.py
@@ -23,6 +23,12 @@ def event_loop():
     loop.close()
 
 
+@pytest.fixture(scope="session", autouse=True)
+def set_random_seed():
+    """Set a fixed seed for random number generation to ensure reproducibility."""
+    random.seed(42)
+    yield
+
 @pytest.fixture(scope="session")
 async def bitshares_instance(bitshares_testnet, private_keys, event_loop):
     """Initialize BitShares instance connected to a local testnet."""


### PR DESCRIPTION
This PR introduces a fixed `random.seed(42)` in the conftest.py to ensure deterministic behavior for tests that utilize Python's random module.

The change addresses variability in several tests, which rely on random operations. Without a fixed seed, these tests could produce inconsistent results across runs, complicating debugging and issue reproduction. By setting the seed at the start of the test session, this modification enhances test consistency and reliability, ensuring reproducible outcomes.